### PR TITLE
Check for null payload ptr in postblit & destructor & opAssign

### DIFF
--- a/source/betterc/file.d
+++ b/source/betterc/file.d
@@ -66,21 +66,23 @@ struct File {
 
 	this (this) nothrow @nogc
 	{
-		payload.count++;
+		if (payload !is null)
+			payload.count++;
 	}
 
 	///Ref. counting during structure assignation
 	ref typeof(this) opAssign(ref typeof(this) rhs)
 	{
 		this.payload = rhs.payload;
-		payload.count++;
+		if (payload !is null)
+			payload.count++;
 
 		return this;
 	}
 
 	~this() nothrow @nogc
 	{
-		if (--payload.count == 0) {
+		if (payload !is null && --payload.count == 0) {
 			this.close();
 			free(payload);
 		}

--- a/source/betterc/stringz.d
+++ b/source/betterc/stringz.d
@@ -45,21 +45,23 @@ struct Stringz
 
 	this (this) nothrow @nogc
 	{
-		payload.count++;
+		if (payload !is null)
+			payload.count++;
 	}
 
 	///Ref. counting during structure assignment
 	ref typeof(this) opAssign()(auto ref typeof(this) rhs) nothrow @nogc
 	{
 		this.payload = rhs.payload;
-		payload.count++;
+		if (payload !is null)
+			payload.count++;
 		return this;
 	}
 
 	~this() nothrow @nogc
 	{
 		import core.stdc.stdlib: free;
-		if (--payload.count == 0) {
+		if (payload !is null && --payload.count == 0) {
 			free(payload.dst);
 			free(payload);
 		}

--- a/source/betterc/vector.d
+++ b/source/betterc/vector.d
@@ -77,14 +77,16 @@ struct Vector(T)
 
 	this(this) nothrow @nogc
 	{
-		payload.count++;
+		if (payload !is null)
+			payload.count++;
 	}
 
 	///Ref. counting during structure assignation
 	ref typeof(this) opAssign(ref typeof(this) rhs)
 	{
 		this.payload = rhs.payload;
-		payload.count++;
+		if (payload !is null)
+			payload.count++;
 
 		return this;
 	}
@@ -92,7 +94,7 @@ struct Vector(T)
 	~this() nothrow @nogc
 	{
 		//TODO: call elements destructors if present
-		if (--payload.count == 0) {
+		if (payload !is null && --payload.count == 0) {
 			free(payload.arr);
 			free(payload);
 		}


### PR DESCRIPTION
This is to avoid problems when calling the destructor of an uninitialized `File`/`Stringz`/`Vector` or assigning `File`/`Stringz`/`Vector.init`.